### PR TITLE
Scrub leaked API key and promote Notion knowledge base

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ Open-source, production-ready training pipeline for character identity, motion, 
 
 Currently supports the **Wan 2.1** and **Wan 2.2** model family with 16 training templates across every variant (T2V, I2V, 2.1, 2.2, Lightning-merged, and vanilla), dual-platform deployment (Modal and RunPod), and a complete dataset captioning toolkit.
 
+> **[Notion Knowledge Base](https://www.notion.so/wan-2-2-2-1-musubi-gym-3096930d2e11812b9537dde1fa7942aa)** — Full training methodology, MoE architecture deep-dive, empirical findings, recommended settings, and active research notes.
+
 ## What's In the Box
 
 **Captioning Tools** — Two Python scripts that auto-caption your images and videos for LoRA training. Point them at a folder, set your anchor word, and they generate `.txt` caption files that musubi-tuner reads automatically. Gemini (free) or Replicate (fast).
@@ -129,7 +131,7 @@ Quality over speed. Lower learning rates (2e-5 to 8e-5) consistently outperform 
 
 Our templates document several original findings including bug fixes for undocumented issues in musubi-tuner and validated hyperparameter defaults derived from cross-referencing multiple practitioners' results in the space, rather than untested community defaults.
 
-For the full training methodology, MoE architecture deep-dive, empirical findings, and active research — see our [Notion knowledge base](https://www.notion.so/wan-2-2-2-1-musubi-gym-3096930d2e11812b9537dde1fa7942aa).
+For the full training methodology, MoE architecture deep-dive, empirical findings, and active research — see our **[Notion knowledge base](https://www.notion.so/wan-2-2-2-1-musubi-gym-3096930d2e11812b9537dde1fa7942aa)**.
 
 ## What's Coming
 

--- a/captioning/caption_gemini.py
+++ b/captioning/caption_gemini.py
@@ -21,7 +21,7 @@ Usage:
 Get a Gemini API key free at: https://aistudio.google.com/apikey
 
 Set API key in PowerShell:
-  $env:GEMINI_API_KEY = "AIzaSyBt3QVKZQYa8aDjHu9xkYKSKQkSNR5-StY"
+  $env:GEMINI_API_KEY = "INSERT_YOUR_GEMINI_API_KEY_HERE"
 """
 
 import os
@@ -35,7 +35,7 @@ from pathlib import Path
 
 # Your Gemini API key — set as environment variable GEMINI_API_KEY
 # In PowerShell: $env:GEMINI_API_KEY = "your-key-here"
-GEMINI_API_KEY = os.environ.get("GEMINI_API_KEY", "AIzaSyBt3QVKZQYa8aDjHu9xkYKSKQkSNR5-StY")
+GEMINI_API_KEY = os.environ.get("GEMINI_API_KEY", "INSERT_YOUR_GEMINI_API_KEY_HERE")
 
 # Dataset folders — set these to your actual paths
 IMAGES_DIR = r"datasets\annika\images"    # <-- Your images folder


### PR DESCRIPTION
## Summary

- **Scrub leaked Gemini API key** — `captioning/caption_gemini.py` had a real Google Gemini API key (`AIzaSy...`) hardcoded in both the docstring (line 24) and as the runtime fallback default (line 38). Replaced both with `INSERT_YOUR_GEMINI_API_KEY_HERE`, which also triggers the existing `validate_config()` error message that guides users to set their own key.

- **Promote Notion knowledge base link** — Added a prominent blockquote callout linking to the Notion knowledge base right below the repo description at the top of the README, where it's immediately visible. The existing link in the Methodology section was also bolded for consistency.

## Important

The leaked key (`AIzaSyBt3QVKZQYa8aDjHu9xkYKSKQkSNR5-StY`) should be **revoked immediately** at https://aistudio.google.com/apikey — it will remain in git history even after this merge.